### PR TITLE
Add template-based message generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,3 +301,7 @@ We welcome contributions! Please feel free to submit a Pull Request.
 ## Support
 
 For questions and issues, please open an issue in this repository.
+
+### Generate Message API
+
+The `/api/generate-message` endpoint creates short communications using OpenAI. Provide a JSON body with fields like `goal`, `representative`, `organization`, and optional properties such as `reference`, `components`, `tone`, `channel`, `audience`, and `templateName`. You can also pass `?template=myTemplate` as a query parameter to select a registered template.

--- a/app/api/generate-message/route.ts
+++ b/app/api/generate-message/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { OpenAIService } from '@/lib/services/openai';
+import type { MessageParams } from '@/lib/types';
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json() as MessageParams;
+    const templateName = request.nextUrl.searchParams.get('template') || body.templateName;
+    const params: MessageParams = { ...body, templateName };
+
+    if (!params.goal || !params.representative || !params.organization) {
+      return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
+    }
+
+    const apiKey = process.env.OPENAI_API_KEY || request.headers.get('X-OpenAI-API-Key');
+    if (!apiKey) {
+      return NextResponse.json({ error: 'OpenAI API key not configured' }, { status: 500 });
+    }
+
+    const openai = new OpenAIService(apiKey);
+    const message = await openai.generateMessage(params);
+
+    return NextResponse.json({ success: true, message });
+  } catch (error) {
+    console.error('Message generation error:', error);
+    return NextResponse.json({ error: 'Failed to generate message' }, { status: 500 });
+  }
+}

--- a/lib/templates/message-templates.ts
+++ b/lib/templates/message-templates.ts
@@ -1,0 +1,11 @@
+export const MESSAGE_TEMPLATES: Record<string, string> = {
+  default: `
+You are {{representative}} representing {{organization}}. Craft a {{tone}} message via {{channel}} ({{medium}}).
+Audience: {{audience}}. Criticality: {{criticalityLevel}}.
+Include components: {{components}}.
+Context: {{reference}}
+
+Goal: {{goal}}
+  `.trim()
+};
+

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -78,3 +78,17 @@ export interface EnrichmentSession {
   status: 'active' | 'paused' | 'cancelled' | 'completed';
   startedAt: Date;
 }
+
+export interface MessageParams {
+  reference?: string;
+  goal: string;
+  representative: string;
+  organization: string;
+  components?: string[];
+  tone?: string;
+  channel?: string;
+  medium?: string;
+  audience?: string;
+  criticalityLevel?: string;
+  templateName?: string;
+}


### PR DESCRIPTION
## Summary
- introduce `MESSAGE_TEMPLATES` registry
- extend `generateMessage` to use templates
- allow `/api/generate-message` to pick template via query or body
- add `templateName` to `MessageParams`
- document template option

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684fd9e4596883288479061b9a2f745a