### PR TITLE
Add embeddable results page

### DIFF
--- a/app/api/results/[id]/route.ts
+++ b/app/api/results/[id]/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse, NextRequest } from 'next/server';
+import { initDB, createTablesIfNotExists, getSessionResults } from '@/lib/services/db';
+
+export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    await initDB();
+    await createTablesIfNotExists();
+    const results = await getSessionResults(params.id);
+    return NextResponse.json({ results });
+  } catch (error) {
+    console.error('Failed to fetch session results:', error);
+    return NextResponse.json({ error: 'Failed to fetch session results' }, { status: 500 });
+  }
+}

--- a/app/embed/[id]/page.tsx
+++ b/app/embed/[id]/page.tsx
@@ -1,0 +1,13 @@
+import EmbedTable from '../embed-table';
+
+interface EmbedPageProps {
+  params: { id: string };
+}
+
+export default function EmbedPage({ params }: EmbedPageProps) {
+  return (
+    <div className="p-4">
+      <EmbedTable sessionId={params.id} />
+    </div>
+  );
+}

--- a/app/embed/embed-table.tsx
+++ b/app/embed/embed-table.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import type { RowEnrichmentResult } from '@/lib/types';
+
+interface EmbedTableProps {
+  sessionId: string;
+}
+
+export default function EmbedTable({ sessionId }: EmbedTableProps) {
+  const [rows, setRows] = useState<RowEnrichmentResult[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchResults = async () => {
+      try {
+        const res = await fetch(`/api/results/${sessionId}`);
+        if (res.ok) {
+          const data = await res.json();
+          setRows(data.results || []);
+        }
+      } catch (err) {
+        console.error('Failed to load results', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchResults();
+  }, [sessionId]);
+
+  if (loading) {
+    return <div className="p-4 text-sm text-muted-foreground">Loading...</div>;
+  }
+
+  if (!rows.length) {
+    return <div className="p-4 text-sm text-muted-foreground">No results</div>;
+  }
+
+  const columns = [
+    ...Object.keys(rows[0].originalData),
+    ...Object.keys(rows[0].enrichments),
+  ];
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          {columns.map(col => (
+            <TableHead key={col}>{col}</TableHead>
+          ))}
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {rows.map((row, i) => (
+          <TableRow key={i}>
+            {columns.map(col => {
+              const val = row.originalData[col] ?? row.enrichments[col]?.value ?? '';
+              return <TableCell key={col}>{String(val)}</TableCell>;
+            })}
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}

--- a/lib/services/db.ts
+++ b/lib/services/db.ts
@@ -130,3 +130,19 @@ export async function updateSessionStatus(sessionId: string, status: EnrichmentS
     throw new Error('Database not initialized');
   }
 }
+
+export async function getSessionResults(sessionId: string): Promise<RowEnrichmentResult[]> {
+  if (pgPool) {
+    const { rows } = await pgPool.query('SELECT data FROM enrichment_results WHERE session_id = $1 ORDER BY row_index', [sessionId]);
+    return rows.map(r => (typeof r.data === 'string' ? JSON.parse(r.data) : r.data));
+  } else if (cassandra) {
+    const result = await cassandra.execute(
+      'SELECT data FROM enrichment_results WHERE session_id = ? ORDER BY row_index',
+      [sessionId],
+      { prepare: true }
+    );
+    return result.rows.map(r => (typeof r['data'] === 'string' ? JSON.parse(r['data']) : r['data']));
+  } else {
+    throw new Error('Database not initialized');
+  }
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -24,6 +24,19 @@ const nextConfig: NextConfig = {
   typescript: {
     ignoreBuildErrors: false,
   },
+  async headers() {
+    return [
+      {
+        source: '/embed/:path*',
+        headers: [
+          {
+            key: 'X-Frame-Options',
+            value: 'ALLOWALL',
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- add DB function to fetch session results
- expose `/api/results/[id]` endpoint
- create `EmbedTable` for rendering session results in a table
- add dynamic embed page using `EmbedTable`
- allow embedding pages under `/embed/*` via `X-Frame-Options` header

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685345e82a9c83288b438525780c814a