### PR TITLE
Add metrics feedback loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,3 +326,7 @@ For questions and issues, please open an issue in this repository.
 ### Generate Message API
 
 The `/api/generate-message` endpoint creates short communications using OpenAI. Provide a JSON body with fields like `goal`, `representative`, `organization`, and optional properties such as `reference`, `components`, `tone`, `channel`, `audience`, and `templateName`. You can also pass `?template=myTemplate` as a query parameter to select a registered template.
+
+## Adaptive Prompt Learning
+
+After each enrichment session finishes, the server calculates metrics like average confidence, missing fields and error counts. These metrics are stored in the `enrichment_metrics` table and fed back into the agent orchestrator. When confidence drops or certain fields are often missing, the orchestrator tweaks its prompt templates and can reorder agents to focus on weaker areas. Over time this learning loop helps improve the quality of future enrichments.

--- a/app/api/enrich/route.ts
+++ b/app/api/enrich/route.ts
@@ -9,7 +9,10 @@ import {
   saveRowResult,
   updateSessionStatus,
   incrementProcessedRows,
+  saveEnrichmentMetrics,
+  getSessionResults,
 } from '@/lib/services/db';
+import { aggregateMetrics } from '@/lib/services/feedback';
 
 // Use Node.js runtime for better compatibility
 export const runtime = 'nodejs';
@@ -265,6 +268,10 @@ export async function POST(request: NextRequest) {
             sessionId,
             abortController.signal.aborted ? 'cancelled' : 'completed'
           );
+          const results = await getSessionResults(sessionId);
+          const metrics = aggregateMetrics(results);
+          await saveEnrichmentMetrics(sessionId, metrics);
+          enrichmentStrategy.updateStrategiesFromMetrics(metrics);
           activeSessions.delete(sessionId);
           controller.close();
         }

--- a/lib/services/feedback.ts
+++ b/lib/services/feedback.ts
@@ -1,0 +1,33 @@
+export interface EnrichmentMetrics {
+  averageConfidence: number;
+  missingFields: Record<string, number>;
+  errorCount: number;
+}
+
+import type { RowEnrichmentResult } from '../types';
+
+export function aggregateMetrics(results: RowEnrichmentResult[]): EnrichmentMetrics {
+  let totalConfidence = 0;
+  let confidenceCount = 0;
+  const missingFields: Record<string, number> = {};
+  let errorCount = 0;
+
+  for (const result of results) {
+    if (result.status === 'error') {
+      errorCount++;
+    }
+    for (const [field, enrichment] of Object.entries(result.enrichments)) {
+      const value = (enrichment as any)?.value;
+      if (value === undefined || value === null || (typeof value === 'string' && value.trim() === '')) {
+        missingFields[field] = (missingFields[field] || 0) + 1;
+      }
+      if (typeof enrichment.confidence === 'number') {
+        totalConfidence += enrichment.confidence;
+        confidenceCount++;
+      }
+    }
+  }
+
+  const averageConfidence = confidenceCount > 0 ? totalConfidence / confidenceCount : 0;
+  return { averageConfidence, missingFields, errorCount };
+}

--- a/lib/strategies/agent-enrichment-strategy.ts
+++ b/lib/strategies/agent-enrichment-strategy.ts
@@ -11,6 +11,10 @@ export class AgentEnrichmentStrategy {
   ) {
     this.orchestrator = new AgentOrchestrator(firecrawlApiKey, openaiApiKey);
   }
+
+  updateStrategiesFromMetrics(metrics: import('../services/feedback').EnrichmentMetrics) {
+    this.orchestrator.updateStrategiesFromMetrics(metrics);
+  }
   
   async enrichRow(
     row: CSVRow,


### PR DESCRIPTION
## Summary
- aggregate row metrics after each enrichment session
- persist enrichment metrics in the database
- let `AgentOrchestrator` update strategies from collected metrics
- feed metrics into orchestrator when sessions complete
- document the adaptive learning loop in the README

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854610bd97083288c5c58845bfdbaa0