### PR TITLE
Improve copy and add dark mode toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img src="https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExNjJwMnF2cW5zbXBhbGV6NXBpb3lkZmVhMWEwY3hmdmt3d3ZtbWc5YSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/QhpbWI09KyFZ0rwD72/giphy.gif" alt="ReconnAIssance Demo" width="100%" />
 </div>
 
-Turn a simple list of emails into a rich dataset with company profiles, funding data, tech stacks, and more. Powered by [{{SCRAPER_SERVICE_NAME}}](https://www.{{SCRAPER_SERVICE_DOMAIN}}/) and a multi-agent AI system.
+Turn a simple contact list into a rich dataset with company profiles, funding data, tech stacks, and more. Powered by [{{SCRAPER_SERVICE_NAME}}](https://www.{{SCRAPER_SERVICE_DOMAIN}}/) and a multi-agent AI system.
 
 ## Technologies
 
@@ -246,7 +246,7 @@ This design allows ReconnAIssance to grow with your needs while maintaining type
 
 ### Process Flow
 
-1.  **Upload & Parse**: Upload a CSV with emails. The system extracts the company domain from each email.
+1.  **Upload & Parse**: Upload a CSV with your contact identifiers (emails, domains, etc.). The system extracts useful details like company domains.
 2.  **Field Selection**: Choose the data points you need, from company descriptions to funding stages.
 3.  **Sequential Agent Execution**: Agents activate in phases, each building on previous discoveries for maximum accuracy.
 4.  **Parallel Searches Per Phase**: Within each phase, multiple searches run concurrently using the {{SCRAPER_SERVICE_NAME}} API.

--- a/app/fire-enrich/README.md
+++ b/app/fire-enrich/README.md
@@ -4,7 +4,7 @@ A powerful AI-powered CSV enrichment tool that transforms basic contact lists in
 
 ## Overview
 
-ReconnAIssance is an advanced data enrichment platform that takes CSV files containing company email addresses and automatically enhances them with valuable business information. Built on a sophisticated multi-agent architecture, it leverages {{SCRAPER_SERVICE_NAME}} for web scraping and OpenAI GPT-4 for intelligent data extraction.
+ReconnAIssance is an advanced data enrichment platform that accepts CSV files with contact identifiers (such as company emails or domains) and automatically enhances them with valuable business information. Built on a sophisticated multi-agent architecture, it leverages {{SCRAPER_SERVICE_NAME}} for web scraping and OpenAI GPT-4 for intelligent data extraction.
 
 ## Architecture
 
@@ -48,20 +48,20 @@ ReconnAIssance employs five specialized AI agents, each optimized for specific d
 
 #### Step 1: CSV Upload
 ```
-User uploads CSV → Parse with Papa Parse → Auto-detect email columns → 
+User uploads CSV → Parse with Papa Parse → Auto-detect identifier columns (e.g., email) →
 Extract unique domains → Preview data structure
 ```
 
 #### Step 2: Field Configuration
 ```
-Select email column → Choose enrichment fields → Add custom fields →
+Select identifier column → Choose enrichment fields → Add custom fields →
 Toggle agent mode → Preview enrichment plan
 ```
 
 #### Step 3: Real-time Enrichment
 ```
 For each row:
-├─ Extract company from email
+├─ Extract company from identifier (email domain or similar)
 ├─ Generate search queries
 ├─ Scrape multiple sources (Firecrawl)
 ├─ Select specialized agents
@@ -133,8 +133,8 @@ If you prefer not to use environment variables, ReconnAIssance supports entering
 
 ## Features
 
-### Smart Email Detection
-- Regex-based email column detection
+### Smart Identifier Detection
+- Regex-based identifier column detection (emails, domains)
 - Domain extraction with edge case handling
 - Company name inference from email patterns
 

--- a/app/fire-enrich/csv-uploader.tsx
+++ b/app/fire-enrich/csv-uploader.tsx
@@ -97,7 +97,7 @@ export function CSVUploader({ onUpload }: CSVUploaderProps) {
       <div className="text-center mb-6">
         <h2 className="text-xl font-semibold mb-1">Upload Your CSV File</h2>
         <p className="text-sm text-muted-foreground">
-          Start by uploading a CSV file containing email addresses
+          Start by uploading a CSV file with contact identifiers (emails, domains, etc.)
         </p>
       </div>
 
@@ -197,9 +197,9 @@ export function CSVUploader({ onUpload }: CSVUploaderProps) {
             <div className="w-6 h-6 bg-[#36322F] rounded flex items-center justify-center dark:bg-zinc-700">
               <span className="text-white text-xs font-bold">@</span>
             </div>
-            <h3 className="text-sm font-medium text-[#36322F] dark:text-white">Email Required</h3>
+            <h3 className="text-sm font-medium text-[#36322F] dark:text-white">Identifier Column</h3>
           </div>
-          <p className="text-xs text-muted-foreground">Must contain email addresses</p>
+          <p className="text-xs text-muted-foreground">Must include contact identifiers</p>
         </div>
         
         <div className="p-3 bg-zinc-100 rounded-lg border border-zinc-200 dark:bg-zinc-800 dark:border-zinc-700">

--- a/app/fire-enrich/page.tsx
+++ b/app/fire-enrich/page.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { ArrowLeft, ExternalLink, Loader2 } from "lucide-react";
+import { ThemeToggle } from "@/components/theme-toggle";
 import { CSVUploader } from "./csv-uploader";
 import { UnifiedEnrichmentView } from "./unified-enrichment-view";
 import { EnrichmentTable } from "./enrichment-table";
@@ -204,22 +205,25 @@ export default function CSVEnrichmentPage() {
             height={32}
           />
         </Link>
-        <Button
-          asChild
-          variant="code"
-          className="font-medium flex items-center gap-2"
-        >
-          <a
-            href="https://github.com/mendableai/firecrawl/tree/main/examples"
-            target="_blank"
-            rel="noopener noreferrer"
+        <div className="flex items-center gap-2">
+          <ThemeToggle />
+          <Button
+            asChild
+            variant="code"
+            className="font-medium flex items-center gap-2"
           >
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="w-4 h-4">
-              <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
-            </svg>
-            Use this template
-          </a>
-        </Button>
+            <a
+              href="https://github.com/mendableai/firecrawl/tree/main/examples"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="w-4 h-4">
+                <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+              </svg>
+              Use this template
+            </a>
+          </Button>
+        </div>
       </div>
 
       <div className="text-center pt-8 pb-6">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
-import { Toaster } from "sonner";
+import { ThemeProvider } from "next-themes";
+import { Toaster } from "@/components/ui/sonner";
 import "./globals.css";
 
 const inter = Inter({ 
@@ -19,10 +20,12 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body className={`${inter.variable} font-sans`}>
-        {children}
-        <Toaster />
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+          {children}
+          <Toaster />
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { ArrowLeft, ExternalLink, Loader2 } from "lucide-react";
+import { ThemeToggle } from "@/components/theme-toggle";
 import { CSVUploader } from "./fire-enrich/csv-uploader";
 import { UnifiedEnrichmentView } from "./fire-enrich/unified-enrichment-view";
 import { EnrichmentTable } from "./fire-enrich/enrichment-table";
@@ -205,22 +206,25 @@ export default function HomePage() {
             height={32}
           />
         </Link>
-        <Button
-          asChild
-          variant="code"
-          className="font-medium flex items-center gap-2"
-        >
-          <a
-            href="https://github.com/mendableai/fire-enrich"
-            target="_blank"
-            rel="noopener noreferrer"
+        <div className="flex items-center gap-2">
+          <ThemeToggle />
+          <Button
+            asChild
+            variant="code"
+            className="font-medium flex items-center gap-2"
           >
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="w-4 h-4">
-              <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
-            </svg>
-            Use this template
-          </a>
-        </Button>
+            <a
+              href="https://github.com/mendableai/fire-enrich"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="w-4 h-4">
+                <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+              </svg>
+              Use this template
+            </a>
+          </Button>
+        </div>
       </div>
 
       <div className="text-center pt-8 pb-6">

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { Button } from "@/components/ui/button";
+import { Sun, Moon } from "lucide-react";
+import { useState, useEffect } from "react";
+
+export function ThemeToggle() {
+  const { setTheme, resolvedTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted) return null;
+
+  const isDark = resolvedTheme === "dark";
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={() => setTheme(isDark ? "light" : "dark")}
+      aria-label="Toggle theme"
+    >
+      {isDark ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
+    </Button>
+  );
+}


### PR DESCRIPTION
## Summary
- wrap app in `ThemeProvider` and add `ThemeToggle` component
- include theme toggle in page headers
- reword CSV upload instructions to allow identifiers beyond email
- update documentation to match new flexible approach

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686c1441f7908328a358731e517659f2