### PR TITLE
Fix dark mode text contrast

### DIFF
--- a/app/fire-enrich/csv-preview.tsx
+++ b/app/fire-enrich/csv-preview.tsx
@@ -56,7 +56,7 @@ export function CSVPreview({ rows, columns, onEmailColumnConfirmed }: CSVPreview
         )}
         
         <div className="flex items-center gap-2 ml-auto">
-          <label className="text-xs font-medium text-gray-700">
+          <label className="text-xs font-medium text-muted-foreground">
             Select email column:
           </label>
           <Select value={selectedColumn} onValueChange={setSelectedColumn}>
@@ -76,18 +76,18 @@ export function CSVPreview({ rows, columns, onEmailColumnConfirmed }: CSVPreview
 
       <div>
         <h3 className="text-sm font-semibold mb-2">Preview (First 5 Rows)</h3>
-        <div className="border border-gray-200 rounded overflow-hidden">
+        <div className="border border-border rounded overflow-hidden">
           <div className="overflow-x-auto max-h-60">
-            <table className="min-w-full divide-y divide-gray-200 text-xs">
-              <thead className="bg-gray-50 sticky top-0">
+            <table className="min-w-full divide-y divide-border text-xs">
+              <thead className="bg-muted sticky top-0">
                 <tr>
                   {columns.map((column) => (
                     <th
                       key={column}
                       className={`px-3 py-2 text-left font-medium uppercase tracking-wider ${
                         column === selectedColumn
-                          ? 'text-black bg-gray-100'
-                          : 'text-gray-500'
+                          ? 'text-foreground bg-muted'
+                          : 'text-muted-foreground'
                       }`}
                     >
                       {column}
@@ -98,16 +98,16 @@ export function CSVPreview({ rows, columns, onEmailColumnConfirmed }: CSVPreview
                   ))}
                 </tr>
               </thead>
-              <tbody className="bg-white divide-y divide-gray-200">
+              <tbody className="bg-background divide-y divide-border">
                 {previewRows.map((row, index) => (
-                  <tr key={index} className="hover:bg-gray-50">
+                  <tr key={index} className="hover:bg-muted">
                     {columns.map((column) => (
                       <td
                         key={column}
                         className={`px-3 py-1.5 whitespace-nowrap ${
                           column === selectedColumn
-                            ? 'font-medium text-gray-900 bg-orange-50'
-                            : 'text-gray-500'
+                            ? 'font-medium text-foreground bg-orange-50 dark:bg-orange-950/20'
+                            : 'text-muted-foreground'
                         }`}
                       >
                         <div className="truncate max-w-xs" title={row[column] || '-'}>
@@ -118,10 +118,10 @@ export function CSVPreview({ rows, columns, onEmailColumnConfirmed }: CSVPreview
                   </tr>
                 ))}
                 {hasMoreRows && (
-                  <tr className="bg-gray-50">
+                  <tr className="bg-muted">
                     <td
                       colSpan={columns.length}
-                      className="px-3 py-2 text-center text-gray-400 italic"
+                      className="px-3 py-2 text-center text-muted-foreground italic"
                     >
                       ... and {rows.length - 5} more rows
                     </td>

--- a/app/fire-enrich/detail-modal.tsx
+++ b/app/fire-enrich/detail-modal.tsx
@@ -55,7 +55,7 @@ export function DetailModal({ isOpen, onClose, row, result, fields, emailColumn 
                   href={websiteUrl.startsWith('http') ? websiteUrl : `https://${websiteUrl}`}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1 text-gray-300 hover:text-white text-xs mt-0.5 transition-colors ml-3"
+                  className="inline-flex items-center gap-1 text-muted-foreground hover:text-white text-xs mt-0.5 transition-colors ml-3"
                 >
                   <ExternalLink className="w-3 h-3" />
                   Visit Website
@@ -69,8 +69,8 @@ export function DetailModal({ isOpen, onClose, row, result, fields, emailColumn 
           {/* Email and Basic Info */}
           <div className="mb-4">
             <div className="flex items-center gap-2">
-              <Mail className="w-4 h-4 text-gray-400" />
-              <span className="text-gray-900 font-medium text-sm">{emailColumn ? row[emailColumn] : Object.values(row)[0]}</span>
+              <Mail className="w-4 h-4 text-muted-foreground" />
+              <span className="text-foreground font-medium text-sm">{emailColumn ? row[emailColumn] : Object.values(row)[0]}</span>
             </div>
           </div>
           
@@ -88,9 +88,9 @@ export function DetailModal({ isOpen, onClose, row, result, fields, emailColumn 
                   }
                   
                   return (
-                    <div key={field.name} className="bg-gray-50 rounded-lg p-3">
+                    <div key={field.name} className="bg-muted rounded-lg p-3">
                       <div className="flex items-start justify-between mb-2">
-                        <h4 className="font-medium text-gray-900 text-sm">{field.displayName}</h4>
+                        <h4 className="font-medium text-foreground text-sm">{field.displayName}</h4>
                         <div className="flex items-center gap-2">
                           {(enrichment.source || enrichment.sourceContext) && (
                             <div className="flex flex-wrap gap-1">
@@ -101,7 +101,7 @@ export function DetailModal({ isOpen, onClose, row, result, fields, emailColumn 
                                     href={ctx.url}
                                     target="_blank"
                                     rel="noopener noreferrer"
-                                    className="inline-flex items-center px-1.5 py-0.5 rounded text-xs bg-gray-200 text-gray-600 hover:bg-gray-300"
+                                    className="inline-flex items-center px-1.5 py-0.5 rounded text-xs bg-muted text-muted-foreground hover:bg-muted"
                                     title={ctx.snippet || 'View source'}
                                   >
                                     <ExternalLink className="w-3 h-3 mr-0.5" />
@@ -115,7 +115,7 @@ export function DetailModal({ isOpen, onClose, row, result, fields, emailColumn 
                                     href={url}
                                     target="_blank"
                                     rel="noopener noreferrer"
-                                    className="inline-flex items-center px-1.5 py-0.5 rounded text-xs bg-gray-200 text-gray-600 hover:bg-gray-300"
+                                    className="inline-flex items-center px-1.5 py-0.5 rounded text-xs bg-muted text-muted-foreground hover:bg-muted"
                                   >
                                     <ExternalLink className="w-3 h-3 mr-0.5" />
                                     {(() => {
@@ -132,7 +132,7 @@ export function DetailModal({ isOpen, onClose, row, result, fields, emailColumn 
                           )}
                         </div>
                       </div>
-                      <div className="text-gray-700 text-sm">
+                      <div className="text-muted-foreground text-sm">
                         {field.type === 'boolean' ? (
                           <div className="flex items-center gap-1">
                             {enrichment.value === true || enrichment.value === 'true' || enrichment.value === 'Yes' ? (
@@ -175,7 +175,7 @@ export function DetailModal({ isOpen, onClose, row, result, fields, emailColumn 
                 return (
                   <div key={field.name} className="mt-4 bg-blue-50 rounded-lg p-4">
                     <div className="flex items-start justify-between mb-2">
-                      <h4 className="font-medium text-gray-900 text-sm">
+                      <h4 className="font-medium text-foreground text-sm">
                         {field.displayName}
                       </h4>
                       {enrichment.source && (
@@ -186,7 +186,7 @@ export function DetailModal({ isOpen, onClose, row, result, fields, emailColumn 
                               href={url} 
                               target="_blank" 
                               rel="noopener noreferrer"
-                              className="block text-gray-600 hover:text-blue-600"
+                              className="block text-muted-foreground hover:text-blue-600"
                             >
                               {(() => {
                                 try {
@@ -200,7 +200,7 @@ export function DetailModal({ isOpen, onClose, row, result, fields, emailColumn 
                         </div>
                       )}
                     </div>
-                    <p className="text-gray-700 text-sm leading-relaxed">{enrichment.value}</p>
+                    <p className="text-muted-foreground text-sm leading-relaxed">{enrichment.value}</p>
                   </div>
                 );
               })}
@@ -209,15 +209,15 @@ export function DetailModal({ isOpen, onClose, row, result, fields, emailColumn 
           
           {/* Original Data Section - Collapsed by default */}
           <details className="mt-4 border-t pt-3">
-            <summary className="cursor-pointer text-xs font-medium text-gray-600 hover:text-gray-900 flex items-center gap-1">
+            <summary className="cursor-pointer text-xs font-medium text-muted-foreground hover:text-foreground flex items-center gap-1">
               <ChevronDown className="w-3 h-3" />
               View Original Data
             </summary>
-            <div className="mt-2 bg-gray-50 rounded p-2 space-y-1">
+            <div className="mt-2 bg-muted rounded p-2 space-y-1">
               {Object.entries(row).map(([key, value]) => (
                 <div key={key} className="flex text-xs">
-                  <span className="font-medium text-gray-600 w-28">{key}:</span>
-                  <span className="text-gray-900">{value}</span>
+                  <span className="font-medium text-muted-foreground w-28">{key}:</span>
+                  <span className="text-foreground">{value}</span>
                 </div>
               ))}
             </div>

--- a/app/fire-enrich/enrichment-table.tsx
+++ b/app/fire-enrich/enrichment-table.tsx
@@ -461,7 +461,7 @@ export function EnrichmentTable({ rows, fields, emailColumn }: EnrichmentTablePr
 
   return (
     <div className="space-y-4">
-      <Card className="p-4 bg-white dark:bg-zinc-900 border-zinc-200 dark:border-zinc-800">
+      <Card className="p-4 bg-background dark:bg-zinc-900 border-zinc-200 dark:border-zinc-800">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-6">
             {/* Progress indicator */}
@@ -580,7 +580,7 @@ export function EnrichmentTable({ rows, fields, emailColumn }: EnrichmentTablePr
 
       {/* Agent Progress Messages */}
       {agentMessages.length > 0 && (
-        <Card className="p-3 bg-white dark:bg-zinc-900 border-zinc-200 dark:border-zinc-800">
+        <Card className="p-3 bg-background dark:bg-zinc-900 border-zinc-200 dark:border-zinc-800">
           <h4 className="text-sm font-semibold text-zinc-700 dark:text-zinc-300 mb-2">
             Agent Activity Log
           </h4>
@@ -614,16 +614,16 @@ export function EnrichmentTable({ rows, fields, emailColumn }: EnrichmentTablePr
         </Card>
       )}
 
-      <div className="overflow-hidden rounded-lg shadow-sm border border-gray-200">
-        <div className="overflow-x-auto bg-white">
+      <div className="overflow-hidden rounded-lg shadow-sm border border-border">
+        <div className="overflow-x-auto bg-background">
           <table className="min-w-full relative">
           <thead>
             <tr className="border-b-2 border-orange-100">
-              <th className="sticky left-0 z-10 bg-white dark:bg-zinc-900 px-4 py-3 text-left text-sm font-semibold text-gray-700 dark:text-gray-300 border-r-2 border-orange-400 shadow-[2px_0_8px_rgba(251,146,60,0.3)]">
+              <th className="sticky left-0 z-10 bg-background dark:bg-zinc-900 px-4 py-3 text-left text-sm font-semibold text-foreground dark:text-muted-foreground border-r-2 border-orange-400 shadow-[2px_0_8px_rgba(251,146,60,0.3)]">
                 {emailColumn || 'Email'}
               </th>
               {fields.map(field => (
-                <th key={field.name} className="px-4 py-3 text-left text-sm font-medium text-gray-700 bg-gray-50">
+                <th key={field.name} className="px-4 py-3 text-left text-sm font-medium text-foreground bg-muted">
                   {field.displayName}
                 </th>
               ))}
@@ -637,13 +637,13 @@ export function EnrichmentTable({ rows, fields, emailColumn }: EnrichmentTablePr
               return (
                 <tr key={index} className={`
                   ${isProcessing ? 'animate-processing-row' : 
-                    index % 2 === 0 ? 'bg-white' : 'bg-gray-50/50'} 
+                    index % 2 === 0 ? 'bg-background' : 'bg-muted/50'} 
                   hover:bg-orange-50/50 transition-all duration-300 group
                 `}>
                   <td className={`
                     sticky left-0 z-10 px-4 py-2 text-sm font-medium
                     ${isProcessing ? 'bg-orange-50 dark:bg-orange-950/10' : 
-                      'bg-white dark:bg-zinc-900'}
+                      'bg-background dark:bg-zinc-900'}
                     border-r-2 border-orange-400 shadow-[2px_0_8px_rgba(251,146,60,0.3)]
                   `}>
                     <div className="space-y-1">
@@ -670,19 +670,19 @@ export function EnrichmentTable({ rows, fields, emailColumn }: EnrichmentTablePr
                           </div>
                         )}
                         <div className="flex items-center gap-1">
-                          <div className="text-gray-800 font-mono text-sm truncate max-w-[180px]">
+                          <div className="text-foreground font-mono text-sm truncate max-w-[180px]">
                             {emailColumn ? row[emailColumn] : Object.values(row)[0]}
                           </div>
                           {/* Show additional columns if CSV has many columns */}
                           {Object.keys(row).length > fields.length + 1 && (
-                            <div className="flex items-center gap-1 text-xs text-gray-500">
+                            <div className="flex items-center gap-1 text-xs text-muted-foreground">
                               {Object.keys(row).slice(1, 3).map((key, idx) => (
                                 <span key={idx} className="truncate max-w-[60px]" title={row[key]}>
                                   {idx > 0 && ', '}{row[key]}
                                 </span>
                               ))}
                               {Object.keys(row).length > 3 && (
-                                <span className="text-gray-400 font-medium">
+                                <span className="text-muted-foreground font-medium">
                                   +{Object.keys(row).length - 3} more
                                 </span>
                               )}
@@ -705,13 +705,13 @@ export function EnrichmentTable({ rows, fields, emailColumn }: EnrichmentTablePr
                   {result?.status === 'skipped' ? (
                     <td 
                       colSpan={fields.length}
-                      className="px-4 py-3 text-sm border-l border-gray-100 bg-gray-50"
+                      className="px-4 py-3 text-sm border-l border-border bg-muted"
                     >
                       <div className="flex flex-col items-start gap-1">
-                        <span className="inline-flex items-center px-2 py-1 bg-gray-100 text-gray-600 rounded-full text-xs font-medium">
+                        <span className="inline-flex items-center px-2 py-1 bg-muted text-muted-foreground rounded-full text-xs font-medium">
                           Skipped
                         </span>
-                        <span className="text-xs text-gray-500">
+                        <span className="text-xs text-muted-foreground">
                           {result.error || 'Personal email provider'}
                         </span>
                       </div>
@@ -731,7 +731,7 @@ export function EnrichmentTable({ rows, fields, emailColumn }: EnrichmentTablePr
                       return (
                         <td 
                           key={field.name} 
-                          className="px-4 py-2 text-sm relative border-l border-gray-100"
+                          className="px-4 py-2 text-sm relative border-l border-border"
                         >
                           {!result ? (
                             <div className="animate-slow-pulse">
@@ -755,7 +755,7 @@ export function EnrichmentTable({ rows, fields, emailColumn }: EnrichmentTablePr
                               animationTimingFunction: 'cubic-bezier(0.4, 0, 0.2, 1)'
                             } : {}}
                           >
-                            <span className="flex items-center gap-1 text-gray-400">
+                            <span className="flex items-center gap-1 text-muted-foreground">
                               <X size={16} />
                               <span className="text-xs">No information found</span>
                             </span>
@@ -771,7 +771,7 @@ export function EnrichmentTable({ rows, fields, emailColumn }: EnrichmentTablePr
                             } : {}}
                           >
                             <div className="flex flex-col gap-1">
-                              <div className="font-medium text-gray-800">
+                              <div className="font-medium text-foreground">
                                 {field.type === 'boolean' ? (
                                   <span className={`inline-flex items-center justify-center w-6 h-6 rounded-full ${
                                     enrichment.value === true || enrichment.value === 'true' || enrichment.value === 'Yes' 
@@ -788,7 +788,7 @@ export function EnrichmentTable({ rows, fields, emailColumn }: EnrichmentTablePr
                                       </span>
                                     ))}
                                     {enrichment.value.length > 2 && (
-                                      <span className="text-xs text-gray-500 font-medium"> +{enrichment.value.length - 2} more</span>
+                                      <span className="text-xs text-muted-foreground font-medium"> +{enrichment.value.length - 2} more</span>
                                     )}
                                   </div>
                                 ) : (
@@ -828,7 +828,7 @@ export function EnrichmentTable({ rows, fields, emailColumn }: EnrichmentTablePr
         open={selectedRow.isOpen} 
         onOpenChange={(open) => setSelectedRow({ ...selectedRow, isOpen: open })}
       >
-        <SheetContent className="w-[550px] sm:max-w-[550px] overflow-y-auto bg-white dark:bg-zinc-900 border-l-2 border-zinc-200 dark:border-zinc-800 px-8">
+        <SheetContent className="w-[550px] sm:max-w-[550px] overflow-y-auto bg-background dark:bg-zinc-900 border-l-2 border-zinc-200 dark:border-zinc-800 px-8">
           {selectedRow.row && (
             <>
               <SheetHeader className="pb-4 border-b border-zinc-200 dark:border-zinc-800">
@@ -949,7 +949,7 @@ export function EnrichmentTable({ rows, fields, emailColumn }: EnrichmentTablePr
                                   {enrichment.corroboration.evidence
                                     .filter(e => e.value !== null)
                                     .map((evidence, idx) => (
-                                      <div key={idx} className="bg-gray-50 dark:bg-zinc-900 rounded p-2 space-y-1">
+                                      <div key={idx} className="bg-muted dark:bg-zinc-900 rounded p-2 space-y-1">
                                         <div className="flex items-start justify-between gap-2">
                                           <a
                                             href={evidence.source_url}
@@ -961,11 +961,11 @@ export function EnrichmentTable({ rows, fields, emailColumn }: EnrichmentTablePr
                                           </a>
                                         </div>
                                         {evidence.exact_text && (
-                                          <p className="text-xs text-gray-600 italic">
+                                          <p className="text-xs text-muted-foreground italic">
                                             &quot;{evidence.exact_text}&quot;
                                           </p>
                                         )}
-                                        <p className="text-xs font-medium text-gray-800">
+                                        <p className="text-xs font-medium text-foreground">
                                           Found: {JSON.stringify(evidence.value)}
                                         </p>
                                       </div>
@@ -1122,41 +1122,41 @@ export function EnrichmentTable({ rows, fields, emailColumn }: EnrichmentTablePr
         if (skippedResults.length === 0) return null;
         
         return (
-          <Card className="p-4 bg-gray-50 dark:bg-zinc-900 border-gray-200 dark:border-zinc-800 mt-4">
+          <Card className="p-4 bg-muted dark:bg-zinc-900 border-border dark:border-zinc-800 mt-4">
             <button
               onClick={() => setShowSkipped(!showSkipped)}
               className="w-full flex items-center justify-between text-left"
             >
               <div className="flex items-center gap-2">
-                <Badge variant="secondary" className="bg-gray-200 text-gray-700">
+                <Badge variant="secondary" className="bg-muted text-foreground">
                   {skippedResults.length} Skipped
                 </Badge>
-                <span className="text-sm text-gray-600 dark:text-gray-400">
+                <span className="text-sm text-muted-foreground dark:text-muted-foreground">
                   Common email providers and domains excluded from enrichment
                 </span>
               </div>
               {showSkipped ? (
-                <ChevronUp className="w-4 h-4 text-gray-400" />
+                <ChevronUp className="w-4 h-4 text-muted-foreground" />
               ) : (
-                <ChevronDown className="w-4 h-4 text-gray-400" />
+                <ChevronDown className="w-4 h-4 text-muted-foreground" />
               )}
             </button>
             
             {showSkipped && (
               <div className="mt-4 space-y-2">
-                <div className="text-xs text-gray-500 mb-2">
+                <div className="text-xs text-muted-foreground mb-2">
                   These emails were skipped to save API calls and processing time:
                 </div>
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
                   {skippedResults.map(({ index, email, reason }) => (
                     <div
                       key={index}
-                      className="flex items-center justify-between bg-white dark:bg-zinc-800 rounded-md px-3 py-2 text-sm"
+                      className="flex items-center justify-between bg-background dark:bg-zinc-800 rounded-md px-3 py-2 text-sm"
                     >
-                      <span className="font-mono text-gray-700 dark:text-gray-300 truncate">
+                      <span className="font-mono text-foreground dark:text-muted-foreground truncate">
                         {email}
                       </span>
-                      <span className="text-xs text-gray-500 ml-2">
+                      <span className="text-xs text-muted-foreground ml-2">
                         {reason}
                       </span>
                     </div>

--- a/app/fire-enrich/field-mapper.tsx
+++ b/app/fire-enrich/field-mapper.tsx
@@ -175,7 +175,7 @@ export function FieldMapper({ onFieldsSelected }: FieldMapperProps) {
         
         {/* Preset fields */}
         <div className="mb-2">
-          <p className="text-xs text-gray-600 mb-1">Quick add fields:</p>
+          <p className="text-xs text-muted-foreground mb-1">Quick add fields:</p>
           <div className="flex flex-wrap gap-1.5">
             {PRESET_FIELDS.map(preset => {
               const isSelected = selectedFields.find(f => f.displayName === preset.displayName) !== undefined;
@@ -186,7 +186,7 @@ export function FieldMapper({ onFieldsSelected }: FieldMapperProps) {
                   disabled={isSelected}
                   className={`inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium transition-all ${
                     isSelected
-                      ? 'bg-gray-100 text-gray-400 cursor-not-allowed'
+                      ? 'bg-muted text-muted-foreground cursor-not-allowed'
                       : 'bg-orange-100 text-orange-900 hover:bg-orange-200'
                   }`}
                 >
@@ -206,7 +206,7 @@ export function FieldMapper({ onFieldsSelected }: FieldMapperProps) {
         {showSuggestions && suggestedFields.length > 0 && (
           <div className="mb-2 p-3 bg-orange-50 rounded-lg border border-orange-200">
             <div className="flex items-center justify-between mb-2">
-              <h4 className="text-sm font-semibold text-gray-900">Suggested Fields</h4>
+              <h4 className="text-sm font-semibold text-foreground">Suggested Fields</h4>
               <div className="flex gap-2">
                 <Button
                   onClick={() => {
@@ -215,7 +215,7 @@ export function FieldMapper({ onFieldsSelected }: FieldMapperProps) {
                   }}
                   variant="outline"
                   size="sm"
-                  className="h-7 px-3 text-xs border-gray-300 hover:bg-gray-100"
+                  className="h-7 px-3 text-xs border-border hover:bg-muted"
                 >
                   Cancel All
                 </Button>
@@ -231,11 +231,11 @@ export function FieldMapper({ onFieldsSelected }: FieldMapperProps) {
             </div>
             <div className="space-y-1.5">
               {suggestedFields.map((field, index) => (
-                <div key={index} className="p-2.5 bg-white rounded-md border border-gray-200">
+                <div key={index} className="p-2.5 bg-background rounded-md border border-border">
                   <div className="flex items-start gap-2">
                     <div className="flex-1">
-                      <div className="font-medium text-sm text-gray-900">{field.displayName}</div>
-                      <div className="text-xs text-gray-600 mt-0.5">{field.description}</div>
+                      <div className="font-medium text-sm text-foreground">{field.displayName}</div>
+                      <div className="text-xs text-muted-foreground mt-0.5">{field.description}</div>
                     </div>
                     <div className="flex gap-0.5">
                       <button
@@ -298,7 +298,7 @@ export function FieldMapper({ onFieldsSelected }: FieldMapperProps) {
               <span title={field.description}>{field.displayName}</span>
               <button
                 onClick={() => removeField(field.name)}
-                className="ml-1 -mr-0.5 inline-flex items-center justify-center w-4 h-4 text-gray-400 hover:text-white hover:bg-gray-700 rounded-full transition-colors"
+                className="ml-1 -mr-0.5 inline-flex items-center justify-center w-4 h-4 text-muted-foreground hover:text-white hover:bg-gray-700 rounded-full transition-colors"
               >
                 <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
                   <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
@@ -314,7 +314,7 @@ export function FieldMapper({ onFieldsSelected }: FieldMapperProps) {
         <div className="border-t pt-2">
           {/* Natural Language Input */}
           <div className="mb-2">
-            <p className="text-xs text-gray-600 mb-1">Describe fields you want to collect:</p>
+            <p className="text-xs text-muted-foreground mb-1">Describe fields you want to collect:</p>
             <div className="flex gap-1">
               <Input
                 type="text"
@@ -343,7 +343,7 @@ export function FieldMapper({ onFieldsSelected }: FieldMapperProps) {
           </div>
           
           {/* Custom field */}
-          <p className="text-xs text-gray-600 mb-1">Or add custom field:</p>
+          <p className="text-xs text-muted-foreground mb-1">Or add custom field:</p>
           <div className="grid grid-cols-3 gap-1">
             <Input
               type="text"

--- a/app/fire-enrich/page.tsx
+++ b/app/fire-enrich/page.tsx
@@ -295,7 +295,7 @@ export default function CSVEnrichmentPage() {
         </div>
       )}
 
-      <footer className="py-8 text-center text-sm text-gray-600 dark:text-gray-400">
+      <footer className="py-8 text-center text-sm text-muted-foreground dark:text-muted-foreground">
         <p className="opacity-75">Made with ❤️ by the ReconnAIssance team</p>
       </footer>
 

--- a/app/fire-enrich/source-context-tooltip.tsx
+++ b/app/fire-enrich/source-context-tooltip.tsx
@@ -91,7 +91,7 @@ export function SourceContextTooltip({ sources, legacySource, sourceCount, corro
             window.dispatchEvent(new CustomEvent('close-other-tooltips', { detail: { excludeRef: buttonRef.current } }));
           }
         }}
-        className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600 hover:bg-gray-200 transition-colors whitespace-nowrap"
+        className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-muted text-muted-foreground hover:bg-muted transition-colors whitespace-nowrap"
         title={hasSnippets ? "View source quotes" : "View sources"}
       >
         <ExternalLink className="w-3 h-3 mr-0.5" />
@@ -104,7 +104,7 @@ export function SourceContextTooltip({ sources, legacySource, sourceCount, corro
       {isExpanded && (
         <div 
           ref={modalRef}
-          className="absolute z-[9999] bg-white border border-gray-200 rounded-lg shadow-lg p-3 space-y-2 max-w-md left-0 mt-2" 
+          className="absolute z-[9999] bg-white border border-border rounded-lg shadow-lg p-3 space-y-2 max-w-md left-0 mt-2" 
           style={{ 
             minWidth: '300px',
             // Position above if near bottom of viewport
@@ -125,9 +125,9 @@ export function SourceContextTooltip({ sources, legacySource, sourceCount, corro
                          : '0'
           }}>
           
-          <div className="mb-2 pb-2 border-b border-gray-100">
+          <div className="mb-2 pb-2 border-b border-border">
             <div className="flex items-center justify-between">
-              <h4 className="text-xs font-semibold text-gray-700">
+              <h4 className="text-xs font-semibold text-muted-foreground">
                 Found in {displaySources.length} {displaySources.length === 1 ? 'source' : 'sources'}
               </h4>
               {confidence && (
@@ -151,11 +151,11 @@ export function SourceContextTooltip({ sources, legacySource, sourceCount, corro
           
           <div className="max-h-64 overflow-y-auto space-y-3">
             {displaySources.map((source, idx) => (
-              <div key={idx} className="border border-gray-100 rounded-lg p-3 hover:border-gray-200 transition-colors">
+              <div key={idx} className="border border-border rounded-lg p-3 hover:border-border transition-colors">
                 {source.snippet && source.snippet.length > 0 ? (
                   <div>
                     {source.snippet && source.snippet.trim() !== '' && (
-                      <p className="text-xs text-gray-700 mb-2 italic leading-relaxed">
+                      <p className="text-xs text-muted-foreground mb-2 italic leading-relaxed">
                         &quot;{source.snippet}&quot;
                       </p>
                     )}

--- a/app/fire-enrich/unified-enrichment-view.tsx
+++ b/app/fire-enrich/unified-enrichment-view.tsx
@@ -206,7 +206,7 @@ export function UnifiedEnrichmentView({ rows, columns, onStartEnrichment }: Unif
                   </TableHead>
                 ))}
                 {step >= 2 && selectedFields.length > maxVisibleFields && (
-                  <TableHead className="text-center text-gray-500 animate-in fade-in duration-700">
+                  <TableHead className="text-center text-muted-foreground animate-in fade-in duration-700">
                     +{selectedFields.length - maxVisibleFields} more
                   </TableHead>
                 )}
@@ -234,7 +234,7 @@ export function UnifiedEnrichmentView({ rows, columns, onStartEnrichment }: Unif
                         >
                           <span className={cn(
                             "text-sm truncate block max-w-[200px] font-mono font-bold",
-                            isValidEmail ? "text-zinc-900 dark:text-zinc-100" : email ? "text-red-600" : "text-gray-400"
+                            isValidEmail ? "text-zinc-900 dark:text-zinc-100" : email ? "text-red-600" : "text-muted-foreground"
                           )}>
                             {email || '-'}
                           </span>
@@ -250,7 +250,7 @@ export function UnifiedEnrichmentView({ rows, columns, onStartEnrichment }: Unif
                           step >= 2 && "opacity-30"
                         )}
                       >
-                        <span className="text-sm truncate block max-w-[150px] text-gray-600">
+                        <span className="text-sm truncate block max-w-[150px] text-muted-foreground">
                           {cellValue || '-'}
                         </span>
                       </TableCell>
@@ -273,7 +273,7 @@ export function UnifiedEnrichmentView({ rows, columns, onStartEnrichment }: Unif
                     </TableCell>
                   ))}
                   {step >= 2 && selectedFields.length > maxVisibleFields && (
-                    <TableCell className="text-center text-gray-400 animate-in fade-in duration-700">
+                    <TableCell className="text-center text-muted-foreground animate-in fade-in duration-700">
                       ...
                     </TableCell>
                   )}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -302,7 +302,7 @@ export default function HomePage() {
         </div>
       )}
 
-      <footer className="py-8 text-center text-sm text-gray-600 dark:text-gray-400">
+      <footer className="py-8 text-center text-sm text-muted-foreground dark:text-muted-foreground">
         <p className="opacity-75">Made with ❤️ by the ReconnAIssance team</p>
       </footer>
 


### PR DESCRIPTION
## Summary
- update dark mode text colors in many components
- use theme variables for muted/foreground text
- ensure table backgrounds and borders respect theme variables

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c441f78b4832890dc1a02f5f78ed0